### PR TITLE
Fix news feed refresh loop

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -69,19 +69,18 @@ function App() {
     if (hasApiKey) {
       loadNews();
       loadStats();
-      
+
       // Connect to monitoring WebSocket
       const newSocket = io('http://localhost:8080');
       setSocket(newSocket);
-      
-      // Refresh news every 30 seconds for testing
+
+      // Refresh stats every 30 seconds
       const interval = setInterval(() => {
-        loadNews();
         loadStats();
-        
+
         // Notify monitoring about frontend refresh
         if (newSocket) {
-          newSocket.emit('frontend-refresh', { articlesCount: news.length });
+          newSocket.emit('frontend-refresh');
         }
       }, 30000);
 
@@ -92,7 +91,7 @@ function App() {
         }
       };
     }
-  }, [hasApiKey, news.length]);
+  }, [hasApiKey]);
 
   const checkSetupStatus = async () => {
     try {


### PR DESCRIPTION
## Summary
- remove polling of news articles every 30 seconds
- keep periodic stats refresh only

## Testing
- `npm test --prefix client --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_688a0ce1c9ac832389d3568e0666f89c